### PR TITLE
Upgrade Apache Commons Collections to v3.2.2

### DIFF
--- a/egov/pom.xml
+++ b/egov/pom.xml
@@ -159,7 +159,7 @@
 		<commons-config-version>1.10</commons-config-version>
 		<commons-lang-version>2.5</commons-lang-version>
 		<commons-email-version>1.4</commons-email-version>
-		<commons-collections-version>3.2.1</commons-collections-version>
+		<commons-collections-version>3.2.2</commons-collections-version>
 		<commons-codec-version>1.10</commons-codec-version>
 		<commons-dbcp-version>1.4</commons-dbcp-version>
 		<commons-io-version>2.4</commons-io-version>


### PR DESCRIPTION
Version 3.2.1 has a CVSS 10.0 vulnerability. That's the worst kind of
vulnerability that exists. By merely existing on the classpath, this
library causes the Java serialization parser for the entire JVM process
to go from being a state machine to a turing machine. A turing machine
with an exec() function!

https://web.nvd.nist.gov/view/vuln/detail?vulnId=CVE-2015-8103
https://commons.apache.org/proper/commons-collections/security-reports.html
http://foxglovesecurity.com/2015/11/06/what-do-weblogic-websphere-jboss-jenkins-opennms-and-your-application-have-in-common-this-vulnerability/